### PR TITLE
add name and description in exampleSite/config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -32,6 +32,10 @@ copyright = "© {year}"
   # linkedin = "<link to your profile>"
   # youtube = "https://www.youtube.com/channel/<your channel>"
   
+  # name and description for meta tags
+  name = "<your name>"
+  description = "<site-wide description>"
+  
   # Titles for your icons (shown as tooltips), and also their display order.
   # Currently, these icons are supported: 
   #   "Twitter", "GitHub", "Email", "Facebook", "GitLab", "Instagram", "LinkedIn", "YouTube"


### PR DESCRIPTION
These fields are honoured by the seoSchema layout but are not used in the exampleSite config. Adding these fields makes it easier for people to learn that these features exist and can be used.